### PR TITLE
Reopen last tab doesn't focus on newly opened tab

### DIFF
--- a/__testcafe__/helpers.js
+++ b/__testcafe__/helpers.js
@@ -19,6 +19,9 @@ export const openLocation = async ( t ) => {
 export const selectPreviousTab = async ( t ) => {
     await clickOnMainMenuItem( ['&File', 'Select Previous Tab'] );
 };
+export const reOpenClosedTab = async ( t ) => {
+    await clickOnMainMenuItem( ['&File', 'Reopen Last Tab'] );
+};
 
 export const getPageTitle = ClientFunction( () => document.title );
 

--- a/__testcafe__/peruse.spec.ts
+++ b/__testcafe__/peruse.spec.ts
@@ -6,7 +6,8 @@ import {
     navigateTo,
     resetStore,
     addTabNext,
-    selectPreviousTab
+    selectPreviousTab,
+    reOpenClosedTab
 } from './helpers';
 
 import { CLASSES } from '../app/constants/classes';
@@ -74,6 +75,20 @@ test( 'can close a tab', async ( t ) => {
         .click( `.${CLASSES.CLOSE_TAB}` )
         .expect( Selector( `.${CLASSES.TAB}` ).count )
         .eql( 1 );
+} );
+
+test( 'can reopen a tab', async ( t ) => {
+    await t
+        .click( `.${CLASSES.ADD_TAB}` )
+        .expect( Selector( `.${CLASSES.TAB}` ).count )
+        .eql( 2 )
+        .click( `.${CLASSES.CLOSE_TAB}` )
+        .expect( Selector( `.${CLASSES.TAB}` ).count )
+        .eql( 1 );
+
+    reOpenClosedTab();
+
+    await t.expect( Selector( `.${CLASSES.TAB}` ).count ).eql( 2 );
 } );
 
 test( 'can type in the address bar and get safe: automatically', async ( t ) => {

--- a/__tests__/reducers/windows.spec.ts
+++ b/__tests__/reducers/windows.spec.ts
@@ -826,7 +826,7 @@ describe( 'windows reducer', () => {
             expect( reopenTab.openWindows[firstWindowId].ui ).toStrictEqual(
                 state.openWindows[firstWindowId].ui
             );
-            expect( reopenTab.openWindows[firstWindowId].activeTab ).toStrictEqual(
+            expect( reopenTab.openWindows[firstWindowId].activeTab ).not.toStrictEqual(
                 state.openWindows[firstWindowId].activeTab
             );
             expect( reopenTab.openWindows[firstWindowId].tabs ).not.toStrictEqual(
@@ -845,6 +845,7 @@ describe( 'windows reducer', () => {
                 openWindows: {
                     [firstWindowId]: {
                         ...basicWindow,
+                        activeTab: tabId2,
                         tabs: [tabId1, tabId2]
                     }
                 },
@@ -892,7 +893,7 @@ describe( 'windows reducer', () => {
             expect( reopenTab.openWindows[firstWindowId].ui ).toStrictEqual(
                 state.openWindows[firstWindowId].ui
             );
-            expect( reopenTab.openWindows[firstWindowId].activeTab ).toStrictEqual(
+            expect( reopenTab.openWindows[firstWindowId].activeTab ).not.toStrictEqual(
                 state.openWindows[firstWindowId].activeTab
             );
             expect( reopenTab.openWindows[firstWindowId].tabs ).not.toStrictEqual(
@@ -911,6 +912,7 @@ describe( 'windows reducer', () => {
                 openWindows: {
                     [firstWindowId]: {
                         ...basicWindow,
+                        activeTab: tabId,
                         tabs: [tabId1, tabId, tabId2]
                     }
                 },
@@ -968,7 +970,7 @@ describe( 'windows reducer', () => {
             expect( reopenTab.openWindows[secondWindowId].ui ).toStrictEqual(
                 state.openWindows[secondWindowId].ui
             );
-            expect( reopenTab.openWindows[secondWindowId].activeTab ).toStrictEqual(
+            expect( reopenTab.openWindows[secondWindowId].activeTab ).not.toStrictEqual(
                 state.openWindows[secondWindowId].activeTab
             );
             expect( reopenTab.openWindows[secondWindowId].tabs ).not.toStrictEqual(
@@ -991,6 +993,7 @@ describe( 'windows reducer', () => {
                     },
                     [secondWindowId]: {
                         ...basicWindow,
+                        activeTab: tabId,
                         tabs: [tabId1, tabId, tabId2]
                     }
                 },

--- a/app/reducers/windows.ts
+++ b/app/reducers/windows.ts
@@ -189,6 +189,8 @@ const reOpenTab = ( state, tabs ) => {
 
     newWindow.tabs.splice( lastTabIndex, 0, tabId );
 
+    newWindow.activeTab = tabId;
+
     newOpenWindows[targetWindowId] = newWindow;
 
     const newState = {


### PR DESCRIPTION
resolves #484 

QA:
To test this PR-
1) Open SAFE browser with multiple (eg 5) tabs open.
2) Close one tab.
3) Select "Reopen the last tab" from OR use CTRL + SHFT + T to open previously closed tab.
4) The focus will change to the newly reopened tab and bring it to the front of the browser window.